### PR TITLE
feat: implement required fields on credential issuer metadata endpoint

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fad7a631b06335cd8983ac131297913c5d6e38f1b42608bb6a1b323ad08dfc55",
+  "originHash" : "b3e1823131be38daacf100d8a368b817501a6c53c2272a2a0b4beae48e4c56cf",
   "pins" : [
     {
       "identity" : "async-http-client",

--- a/Sources/Issuer/Metadata/Claims/AgeClaim.swift
+++ b/Sources/Issuer/Metadata/Claims/AgeClaim.swift
@@ -1,0 +1,8 @@
+struct AgeClaim: Claim {
+    let name: String
+    let value: [String: String] = [:]
+
+    init(age: Int) {
+        self.name = "is_over_\(age)"
+    }
+}

--- a/Sources/Issuer/Metadata/Claims/Claim.swift
+++ b/Sources/Issuer/Metadata/Claims/Claim.swift
@@ -1,0 +1,8 @@
+protocol Claim {
+    associatedtype ClaimValue: Encodable
+
+    var name: String { get }
+    var value: ClaimValue { get }
+}
+
+protocol ClaimValue: Encodable {}

--- a/Sources/Issuer/Metadata/Claims/Claims.swift
+++ b/Sources/Issuer/Metadata/Claims/Claims.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Vapor
+
+enum ClaimEncodingError: Error {
+    case unableToCreateCodingKey
+}
+
+struct Claims: Encodable {
+    let claims: [any Claim]
+
+    var keys: [CodingKey] {
+        claims.enumerated().compactMap {
+            ClaimCodingKey(stringValue: $1.name)
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: ClaimCodingKey.self)
+        try claims.forEach { claim in
+            guard let codingKey = ClaimCodingKey(stringValue: claim.name) else {
+                throw ClaimEncodingError.unableToCreateCodingKey
+            }
+            try container.encode(claim.value, forKey: codingKey)
+        }
+    }
+
+    struct ClaimCodingKey: CodingKey {
+        let stringValue: String
+        let intValue: Int? = nil
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(intValue: Int) {
+            return nil
+        }
+    }
+}
+
+extension Claims: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: any Claim...) {
+        self.init(claims: elements)
+    }
+}

--- a/Sources/Issuer/Metadata/Claims/Claims.swift
+++ b/Sources/Issuer/Metadata/Claims/Claims.swift
@@ -9,8 +9,8 @@ struct Claims: Encodable {
     let claims: [any Claim]
 
     var keys: [CodingKey] {
-        claims.enumerated().compactMap {
-            ClaimCodingKey(stringValue: $1.name)
+        claims.compactMap {
+            ClaimCodingKey(stringValue: $0.name)
         }
     }
 

--- a/Sources/Issuer/Metadata/Claims/FamilyNameClaim.swift
+++ b/Sources/Issuer/Metadata/Claims/FamilyNameClaim.swift
@@ -1,0 +1,5 @@
+struct FamilyNameClaim: Claim {
+    let name = "family_name"
+    let value: [String: String] = [:]
+}
+

--- a/Sources/Issuer/Metadata/Claims/FamilyNameClaim.swift
+++ b/Sources/Issuer/Metadata/Claims/FamilyNameClaim.swift
@@ -2,4 +2,3 @@ struct FamilyNameClaim: Claim {
     let name = "family_name"
     let value: [String: String] = [:]
 }
-

--- a/Sources/Issuer/Metadata/Claims/FirstNameClaim.swift
+++ b/Sources/Issuer/Metadata/Claims/FirstNameClaim.swift
@@ -1,0 +1,4 @@
+struct FirstNameClaim: Claim {
+    let name = "given_name"
+    let value: [String: String] = [:]
+}

--- a/Sources/Issuer/Metadata/CredentialConfiguration.swift
+++ b/Sources/Issuer/Metadata/CredentialConfiguration.swift
@@ -1,21 +1,21 @@
 import Vapor
 
-struct CredentialConfiguration: Content {
+struct CredentialConfiguration: Encodable {
+    let type: String
     let format: String
     let scope: String
+    let claims: Claims
     let supportedCryptographicBindingMethods: [CryptographicBindingMethod]
     let supportedSigningAlgorithms: [SigningAlgorithm]
+    let supportedProofTypes: ProofTypes
 
     enum CodingKeys: String, CodingKey {
-        case format, scope
+        case format, scope, claims
+        case type = "vct"
         case supportedCryptographicBindingMethods = "cryptographic_binding_methods_supported"
         case supportedSigningAlgorithms = "credential_signing_alg_values_supported"
+        case supportedProofTypes = "proof_types_supported"
     }
-}
-
-enum SigningAlgorithm: String, Codable {
-    /// Elliptic Curve Digital Signature Algorithm with the P-256 curve and the SHA-256 hash function
-    case es256 = "ES256"
 }
 
 extension CredentialConfiguration {
@@ -24,10 +24,18 @@ extension CredentialConfiguration {
     // JWT: JSON Web Token
     static var libraryCard: CredentialConfiguration {
         CredentialConfiguration(
+            type: "vc+sd-jwt-library-card-sample-implementation",
             format: "vc+sd-jwt",
             scope: "library.catalogue.read",
+            claims: [
+                FirstNameClaim(),
+                FamilyNameClaim(),
+                AgeClaim(age: 18),
+                AgeClaim(age: 65)
+            ],
             supportedCryptographicBindingMethods: [.jwk],
-            supportedSigningAlgorithms: [.es256]
+            supportedSigningAlgorithms: [.es256],
+            supportedProofTypes: [.jwt]
         )
     }
 }

--- a/Sources/Issuer/Metadata/CredentialIssuer.swift
+++ b/Sources/Issuer/Metadata/CredentialIssuer.swift
@@ -1,6 +1,6 @@
 import Vapor
 
-struct CredentialIssuer: Content {
+struct CredentialIssuer: Encodable {
     let supportedConfigurations: [String: CredentialConfiguration]
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/Issuer/Metadata/CryptographicBindingMethod.swift
+++ b/Sources/Issuer/Metadata/CryptographicBindingMethod.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-enum CryptographicBindingMethod: String, Codable {
+enum CryptographicBindingMethod: String, Encodable {
     case jwk
 }

--- a/Sources/Issuer/Metadata/Proofs/ProofType.swift
+++ b/Sources/Issuer/Metadata/Proofs/ProofType.swift
@@ -1,0 +1,17 @@
+struct ProofType: Encodable {
+    let name: String
+    let supportedSigningAlgorithms: [SigningAlgorithm]
+
+    enum CodingKeys: String, CodingKey {
+        case supportedSigningAlgorithms = "proof_signing_alg_values_supported"
+    }
+}
+
+extension ProofType {
+    static var jwt: ProofType {
+        ProofType(
+            name: "jwt",
+            supportedSigningAlgorithms: [.es256]
+        )
+    }
+}

--- a/Sources/Issuer/Metadata/Proofs/ProofTypes.swift
+++ b/Sources/Issuer/Metadata/Proofs/ProofTypes.swift
@@ -9,8 +9,8 @@ struct ProofTypes: Encodable {
     let proofTypes: [ProofType]
 
     var keys: [CodingKey] {
-        proofTypes.enumerated().compactMap {
-            ProofTypeCodingKey(stringValue: $1.name)
+        proofTypes.compactMap {
+            ProofTypeCodingKey(stringValue: $0.name)
         }
     }
 

--- a/Sources/Issuer/Metadata/Proofs/ProofTypes.swift
+++ b/Sources/Issuer/Metadata/Proofs/ProofTypes.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Vapor
+
+enum ProofTypeEncodingError: Error {
+    case unableToCreateCodingKey
+}
+
+struct ProofTypes: Encodable {
+    let proofTypes: [ProofType]
+
+    var keys: [CodingKey] {
+        proofTypes.enumerated().compactMap {
+            ProofTypeCodingKey(stringValue: $1.name)
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: ProofTypeCodingKey.self)
+        try proofTypes.forEach { proofType in
+            guard let codingKey = ProofTypeCodingKey(stringValue: proofType.name) else {
+                throw ProofTypeEncodingError.unableToCreateCodingKey
+            }
+            try container.encode(proofType, forKey: codingKey)
+        }
+    }
+
+    struct ProofTypeCodingKey: CodingKey {
+        let stringValue: String
+        let intValue: Int? = nil
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(intValue: Int) {
+            return nil
+        }
+    }
+}
+
+extension ProofTypes: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: ProofType...) {
+        self.init(proofTypes: elements)
+    }
+}

--- a/Sources/Issuer/Metadata/SigningAlgorithm.swift
+++ b/Sources/Issuer/Metadata/SigningAlgorithm.swift
@@ -1,0 +1,12 @@
+//
+//  SigningAlgorithm.swift
+//  CredentialIssuer
+//
+//  Created by Oliver Binns on 20/10/2024.
+//
+
+
+enum SigningAlgorithm: String, Encodable {
+    /// Elliptic Curve Digital Signature Algorithm with the P-256 curve and the SHA-256 hash function
+    case es256 = "ES256"
+}

--- a/Sources/Issuer/Metadata/SigningAlgorithm.swift
+++ b/Sources/Issuer/Metadata/SigningAlgorithm.swift
@@ -5,7 +5,6 @@
 //  Created by Oliver Binns on 20/10/2024.
 //
 
-
 enum SigningAlgorithm: String, Encodable {
     /// Elliptic Curve Digital Signature Algorithm with the P-256 curve and the SHA-256 hash function
     case es256 = "ES256"

--- a/Sources/Issuer/Metadata/WellKnown.swift
+++ b/Sources/Issuer/Metadata/WellKnown.swift
@@ -1,13 +1,21 @@
 import Vapor
 
 struct WellKnown: RouteCollection {
+    let encoder = JSONEncoder()
+
     func boot(routes: any RoutesBuilder) throws {
         let wellKnown = routes.grouped(".well-known")
 
-        wellKnown.get("openid-credential-issuer") { req in
-            let issuer = CredentialIssuer(supportedConfigurations: ["library_card": .libraryCard])
-            try req.content.encode(issuer, using: JSONEncoder())
-            return HTTPStatus.ok
+        wellKnown.get("openid-credential-issuer") { _ in
+            let issuer = CredentialIssuer(
+                supportedConfigurations: ["library_card": .libraryCard]
+            )
+            let responseBody = try encoder.encode(issuer)
+            return Response(
+                status: .ok,
+                headers: ["Content-Type": "application/json"],
+                body: .init(data: responseBody)
+            )
         }
     }
 }

--- a/Sources/Issuer/Metadata/WellKnown.swift
+++ b/Sources/Issuer/Metadata/WellKnown.swift
@@ -4,8 +4,10 @@ struct WellKnown: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
         let wellKnown = routes.grouped(".well-known")
 
-        wellKnown.get("openid-credential-issuer") { _ async in
-            CredentialIssuer(supportedConfigurations: ["library_card": .libraryCard])
+        wellKnown.get("openid-credential-issuer") { req in
+            let issuer = CredentialIssuer(supportedConfigurations: ["library_card": .libraryCard])
+            try req.content.encode(issuer, using: JSONEncoder())
+            return HTTPStatus.ok
         }
     }
 }

--- a/Tests/IssuerTests/AppTests.swift
+++ b/Tests/IssuerTests/AppTests.swift
@@ -2,7 +2,7 @@
 import XCTVapor
 
 final class AppTests: XCTestCase {
-    var app: Application!
+    private var app: Application!
 
     override func setUp() async throws {
         self.app = try await Application.make(.testing)
@@ -15,8 +15,15 @@ final class AppTests: XCTestCase {
     }
 
     func testWellKnown() async throws {
-        try await self.app.test(.GET, ".well-known/openid-credential-issuer", afterResponse: { res async in
+        let expectedData = try JSONEncoder().encode(
+            CredentialIssuer(supportedConfigurations: ["library_card": .libraryCard])
+        )
+
+        try await self.app.test(.GET, ".well-known/openid-credential-issuer",
+                                afterResponse: { res async throws in
+
             XCTAssertEqual(res.status, .ok)
+            try XCTAssertEqualJSONData(Data(buffer: res.body), expectedData)
         })
     }
 }

--- a/Tests/IssuerTests/CredentialConfigurationTests.swift
+++ b/Tests/IssuerTests/CredentialConfigurationTests.swift
@@ -40,7 +40,7 @@ struct CredentialConfigurationTests {
             }
           },
           "scope" : "library.catalogue.read",
-          "vct" : "vc+sd-jwt-library-card-sample-implementation",
+          "vct" : "vc+sd-jwt-library-card-sample-implementation"
         }
         """)
     }

--- a/Tests/IssuerTests/CredentialConfigurationTests.swift
+++ b/Tests/IssuerTests/CredentialConfigurationTests.swift
@@ -11,6 +11,20 @@ struct CredentialConfigurationTests {
         let data = try encoder.encode(CredentialConfiguration.libraryCard)
         #expect(String(data: data, encoding: .utf8) == """
         {
+          "claims" : {
+            "family_name" : {
+
+            },
+            "given_name" : {
+
+            },
+            "is_over_18" : {
+
+            },
+            "is_over_65" : {
+
+            }
+          },
           "credential_signing_alg_values_supported" : [
             "ES256"
           ],
@@ -18,7 +32,15 @@ struct CredentialConfigurationTests {
             "jwk"
           ],
           "format" : "vc+sd-jwt",
-          "scope" : "library.catalogue.read"
+          "proof_types_supported" : {
+            "jwt" : {
+              "proof_signing_alg_values_supported" : [
+                "ES256"
+              ]
+            }
+          },
+          "scope" : "library.catalogue.read",
+          "vct" : "vc+sd-jwt-library-card-sample-implementation",
         }
         """)
     }

--- a/Tests/IssuerTests/CredentialIssuerTests.swift
+++ b/Tests/IssuerTests/CredentialIssuerTests.swift
@@ -35,4 +35,3 @@ extension CredentialConfiguration {
         )
     }
 }
-

--- a/Tests/IssuerTests/CredentialIssuerTests.swift
+++ b/Tests/IssuerTests/CredentialIssuerTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+@testable import Issuer
+import Testing
+
+struct CredentialIssuerTests {
+    @Test
+    func encodeIssuer() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        let issuer = CredentialIssuer(supportedConfigurations: [
+            "mock": .mock
+        ])
+
+        let mockData = try encoder.encode(CredentialConfiguration.mock)
+        let mock = try #require(String(data: mockData, encoding: .utf8))
+
+        let data = try encoder.encode(issuer)
+        #expect(String(data: data, encoding: .utf8) == """
+        {"credential_configurations_supported":{"mock":\(mock)}}
+        """)
+    }
+}
+
+extension CredentialConfiguration {
+    static var mock: CredentialConfiguration {
+        CredentialConfiguration(
+            type: "mock-credential",
+            format: "vc+sd-jwt",
+            scope: "mock.read",
+            claims: [FirstNameClaim(), AgeClaim(age: 438)],
+            supportedCryptographicBindingMethods: [.jwk],
+            supportedSigningAlgorithms: [.es256],
+            supportedProofTypes: [.jwt]
+        )
+    }
+}
+

--- a/Tests/IssuerTests/Helper/JSONCompare.swift
+++ b/Tests/IssuerTests/Helper/JSONCompare.swift
@@ -1,0 +1,16 @@
+import Foundation
+import XCTest
+
+func XCTAssertEqualJSONData(_ lhsData: Data, _ rhsData: Data, _ message: String = "") throws {
+    guard let lhs = try JSONSerialization.jsonObject(with: lhsData) as? any Equatable else {
+        XCTFail(message)
+        return
+    }
+    let rhs = try JSONSerialization.jsonObject(with: rhsData)
+
+    func equals<T: Equatable>(_ lhs: T, _ rhs: Any, _ message: String = "") {
+        XCTAssertEqual(lhs, rhs as? T, message)
+    }
+
+    equals(lhs, rhs, message)
+}


### PR DESCRIPTION
Implements the required fields on the credential issuer metadata endpoint (`.well-known/openid-credential-issuer`).

This specification is defined in [OpenID for Verifiable Credential Issuance - draft 14](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#server-metadata-sd-jwt-vc).

Sample response:
```json
{
  "claims" : {
    "family_name" : {

    },
    "given_name" : {

    },
    "is_over_18" : {

    },
    "is_over_65" : {

    }
  },
  "credential_signing_alg_values_supported" : [
    "ES256"
  ],
  "cryptographic_binding_methods_supported" : [
    "jwk"
  ],
  "format" : "vc+sd-jwt",
  "proof_types_supported" : {
    "jwt" : {
      "proof_signing_alg_values_supported" : [
        "ES256"
      ]
    }
  },
  "scope" : "library.catalogue.read",
  "vct" : "vc+sd-jwt-library-card-sample-implementation"
}
```